### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import { TooltipModule, TooltipOptions } from '@teamhive/ngx-tooltip';
         TooltipModule.forRoot({
             // custom defaults go here e.g.
             placement: 'top',
-            arrow: 'true',
+            arrow: true,
             arrowType: 'sharp',
             allowHTML: true,
             maxWidth: 200


### PR DESCRIPTION
Type of TooltipOptions.arrow is boolean not string.